### PR TITLE
Add support for forwarding tracing spans in spawned tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,7 @@ dependencies = [
  "scopeguard",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -341,6 +342,37 @@ dependencies = [
  "hashbrown",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,13 @@ futures-util = "0.3.31"
 pin-project = "1.1.9"
 tokio = "1.43.0"
 tokio-util = { version = "0.7.13", features = ["rt"] }
+tracing = { version = "0.1.41", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.95"
 dashmap = "6.1.0"
 scopeguard = "1.2.0"
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
+
+[features]
+tracing = ["dep:tracing"]

--- a/src/task_wiring.rs
+++ b/src/task_wiring.rs
@@ -64,6 +64,8 @@ where
         }: TaskWiring<Fut>,
     ) -> JoinHandle<Option<Fut::Output>> {
         let future = RunUntilCancelled::new(cancellation_token, future);
+        #[cfg(feature = "tracing")]
+        let future = tracing::Instrument::in_current_span(future);
         task_tracker.spawn(future)
     }
 }
@@ -82,6 +84,8 @@ where
         }: TaskWiring<Fut>,
     ) -> JoinHandle<Option<Result<Fut::Ok, Fut::Error>>> {
         let future = RunUntilCancelled::new(cancellation_token, future.into_future());
+        #[cfg(feature = "tracing")]
+        let future = tracing::Instrument::in_current_span(future);
         task_tracker.spawn(future)
     }
 }


### PR DESCRIPTION
This preserves the parent/child relationship between spans that get created on a parallel task.