### PR TITLE
[FS-427] fix panic in `TryParallelBuffer::poll_next`

### DIFF
--- a/src/try_stream/try_parallel_buffer.rs
+++ b/src/try_stream/try_parallel_buffer.rs
@@ -5,6 +5,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use futures_util::future::{Fuse, FusedFuture, FutureExt};
 use futures_util::Stream;
 use futures_util::{TryFuture, TryStream};
 use tokio_util::sync::CancellationToken;
@@ -30,7 +31,7 @@ where
     #[pin]
     buffer: Option<TryFutBuffer>,
     #[pin]
-    wait: Wait,
+    wait: Fuse<Wait>,
     phantom: PhantomData<St>,
 }
 
@@ -72,7 +73,7 @@ where
 
         let buffer = Some(buffer);
 
-        let wait = Wait::new(Arc::clone(&task_tracker));
+        let wait = Wait::new(Arc::clone(&task_tracker)).fuse();
         let phantom = PhantomData;
 
         Self {
@@ -130,8 +131,10 @@ where
         this.task_tracker.close();
         this.cancellation_token.cancel();
 
-        // Optionally wait for cancelled tasks to finish
-        if *this.awaiting_completion {
+        // Optionally wait for cancelled tasks to finish.
+        // Use is_terminated() to avoid polling the Wait future after it has
+        // returned Ready, which would cause a panic.
+        if *this.awaiting_completion && !this.wait.is_terminated() {
             match this.wait.poll(cx) {
                 Poll::Ready(()) => (),
                 // Still waiting for clean-up to finish

--- a/src/try_stream/try_parallel_buffer_unordered.rs
+++ b/src/try_stream/try_parallel_buffer_unordered.rs
@@ -101,15 +101,18 @@ where
 mod tests {
     use std::collections::HashSet;
     use std::future;
+    use std::future::poll_fn;
+    use std::pin::pin;
     use std::sync::Arc;
 
-    use futures_util::{stream, StreamExt};
+    use futures_util::{stream, Stream, StreamExt};
     use scopeguard::defer;
     use tokio::sync::Semaphore;
     use tokio::task;
     use tokio_util::sync::CancellationToken;
 
     use crate::stream::StreamParExt;
+    use crate::try_stream::TryStreamParExt;
 
     #[tokio::test]
     async fn test_parallel_buffer_unordered() -> anyhow::Result<()> {
@@ -261,5 +264,35 @@ mod tests {
         assert_eq!(panic_msg, "allergic to the number 2");
 
         Ok(())
+    }
+
+    /// Regression test: TryParallelBuffer should not panic when poll_next is
+    /// called after it has returned Some(Err(...)). Previously, the internal
+    /// Wait future would be polled after completion, causing a panic with
+    /// "async fn resumed after completion".
+    #[tokio::test]
+    async fn test_try_parallel_buffer_unordered_no_panic_after_stream_error() {
+        // Create a stream that immediately yields an error
+        let input_stream = stream::iter([Err::<std::future::Ready<Result<u32, &str>>, _>(
+            "stream error",
+        )]);
+
+        let mut buffered = pin!(input_stream.try_parallel_buffer_unordered(4));
+
+        // Poll 1: Should get the stream error
+        let item1 = poll_fn(|cx| buffered.as_mut().poll_next(cx)).await;
+        assert!(
+            matches!(item1, Some(Err("stream error"))),
+            "expected Some(Err(\"stream error\")), got {:?}",
+            item1
+        );
+
+        // Poll 2: This previously caused a panic. Should now return None.
+        let item2 = poll_fn(|cx| buffered.as_mut().poll_next(cx)).await;
+        assert!(
+            item2.is_none(),
+            "expected None after error, got {:?}",
+            item2
+        );
     }
 }


### PR DESCRIPTION
`TryParallelBuffer::poll_next` panics upon being called again efter returning `Poll::Ready(Some(Err(err))).

See regression test. 

Production volumefs2-cleaner panic [logs](https://app.datadoghq.com/logs?query=service%3Avolumefs2-cleaner%20env%3Aprod%20panicked&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZs8jXK6sSz3BQAAABhBWnM4allkX0FBQ1ltQ1pkekhGRUF3QUIAAAAkZjE5YjNjOTEtYjhhNy00MzM3LTk5NzAtNzhjNzlmZmZlYjA4AA7kbQ&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1766245676000&to_ts=1766247476000&live=false):

```
thread 'main' panicked at '`async fn` resumed after completion': /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-par-util-0.2.0/src/future/wait.rs:19
   0: log_panics::Config::install_panic_hook::{{closure}}
   1: std::panicking::panic_with_hook
   2: std::panicking::panic_handler::{{closure}}
   3: std::sys::backtrace::__rust_end_short_backtrace
   4: __rustc::rust_begin_unwind
   5: core::panicking::panic_fmt
   6: core::panicking::panic_const::panic_const_async_fn_resumed
   7: tokio_par_util::future::wait::Wait::new::{{closure}}
   8: <tokio_par_util::try_stream::try_parallel_buffer::TryParallelBuffer<St,TryFutBuffer> as futures_core::stream::Stream>::poll_next
   9: <futures_util::stream::stream::fold::Fold<St,Fut,T,F> as core::future::future::Future>::poll
  10: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll
  11: <core::pin::Pin<P> as core::future::future::Future>::poll
  12: <tokio::runtime::task::trace::Root<T> as core::future::future::Future>::poll
  13: tokio::runtime::park::CachedParkThread::block_on
  14: tokio::runtime::context::runtime::enter_runtime
  15: tokio::runtime::runtime::Runtime::block_on
  16: volumefs2_cleaner::main
  17: std::sys::backtrace::__rust_begin_short_backtrace
  18: std::rt::lang_start::{{closure}}
  19: std::rt::lang_start_internal
  20: main
  21: <unknown>
  22: __libc_start_main
  23: _start
```